### PR TITLE
removes redundant gem dep on Jekyll since we use github-pages

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -10,7 +10,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 3.8.7"
+
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     colorator (1.1.0)
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     dnsruby (1.61.4)
       simpleidn (~> 0.1)
     em-websocket (0.5.1)
@@ -80,7 +80,7 @@ GEM
       octokit (~> 4.0)
       public_suffix (~> 3.0)
       typhoeus (~> 1.3)
-    html-pipeline (2.13.0)
+    html-pipeline (2.14.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.6.0)
@@ -253,7 +253,6 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages (~> 206)
-  jekyll (~> 3.8.7)
   jekyll-feed (~> 0.12)
   just-the-docs
   minima (~> 2.5)


### PR DESCRIPTION
commit to amend upstream PR #1228
